### PR TITLE
Fix NullReferenceException in PageAdapter.get_Count when ItemSource is null

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -227,7 +227,7 @@ namespace CarouselView.FormsPlugin.Android
 
 			public override int Count {
 				get {
-					return Element.ItemsSource.Count;
+					return Element.ItemsSource?.Count ?? 0;
 				}
 			}
 

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -25,7 +25,7 @@ namespace CarouselView.FormsPlugin.iOS
 
 		int Count {
 			get {
-				return Element.ItemsSource.Count;
+				return Element.ItemsSource?.Count ?? 0;
 			}
 		}
 


### PR DESCRIPTION
See: https://github.com/alexrainman/CarouselView/issues/19

P.S. Please, set in order your repository. Add gitignore and delete bin, obj and package files. 
P.P.S This is little changes that plugin work in my project. Please do code review. There are many ItemSource in native implementation that maybe source error. 