### PR TITLE
Add AnimateTransition property and fix iOS PositionSelected calls

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Xamarin.Forms;
 using System.Collections;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace CarouselView.FormsPlugin.Abstractions
 {
@@ -106,6 +106,14 @@ namespace CarouselView.FormsPlugin.Abstractions
 		{
 			get { return (Orientation)GetValue(OrientationProperty); }
 			set { SetValue(OrientationProperty, value); }
+		}
+
+		public static readonly BindableProperty AnimateTransitionProperty = BindableProperty.Create("AnimateTransition", typeof(bool), typeof(CarouselViewControl), true);
+
+		public bool AnimateTransition
+		{
+			get { return (bool)GetValue(AnimateTransitionProperty); }
+			set { SetValue(AnimateTransitionProperty, value); }
 		}
 
 		public EventHandler PositionSelected;

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -1,16 +1,15 @@
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Android.OS;
 using Android.Support.V4.View;
+using Android.Util;
 using CarouselView.FormsPlugin.Abstractions;
 using CarouselView.FormsPlugin.Android;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
-using System.ComponentModel;
-
 using AViews = Android.Views;
-using Android.Util;
-using Android.OS;
 
 [assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer))]
 namespace CarouselView.FormsPlugin.Android
@@ -164,7 +163,7 @@ namespace CarouselView.FormsPlugin.Android
 
 					if (position == 0) {
 
-						viewPager.SetCurrentItem (1, true);
+						viewPager.SetCurrentItem (1, Element.AnimateTransition);
 
 						await Task.Delay (100);
 
@@ -178,7 +177,7 @@ namespace CarouselView.FormsPlugin.Android
 
 					} else {
 
-						viewPager.SetCurrentItem (newPos, true);
+						viewPager.SetCurrentItem (newPos, Element.AnimateTransition);
 
 						await Task.Delay(100);
 
@@ -234,7 +233,7 @@ namespace CarouselView.FormsPlugin.Android
 					throw new CarouselViewException("Current page index cannot be bigger than ItemsSource.Count - 1");
 				
 				Element.Position = position;
-				viewPager.SetCurrentItem (Element.Position, true);
+				viewPager.SetCurrentItem (Element.Position, Element.AnimateTransition);
 			}
 		}
 

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -238,8 +238,7 @@ namespace CarouselView.FormsPlugin.iOS
 
 						ConfigurePageControl();
 
-						if (Element.PositionSelected != null)
-							Element.PositionSelected(Element, EventArgs.Empty);
+						Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
 					}
 					break;
 			}
@@ -255,8 +254,7 @@ namespace CarouselView.FormsPlugin.iOS
 
 				ConfigurePageControl();
 
-				if (Element.PositionSelected != null)
-					Element.PositionSelected(Element, EventArgs.Empty);
+				Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
 			}
 		}
 
@@ -280,8 +278,9 @@ namespace CarouselView.FormsPlugin.iOS
 					await Task.Delay(100);
 					var direction = position == 0 ? UIPageViewControllerNavigationDirection.Forward : UIPageViewControllerNavigationDirection.Reverse;
 					var firstViewController = CreateViewController(newPos);
-					pageController.SetViewControllers(new[] { firstViewController }, direction, true, s =>
+					pageController.SetViewControllers(new[] { firstViewController }, direction, Element.AnimateTransition, s =>
 					{
+						Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
 					});
 
 					Element.Position = newPos;
@@ -292,14 +291,12 @@ namespace CarouselView.FormsPlugin.iOS
 					var firstViewController = pageController.ViewControllers[0];
 					pageController.SetViewControllers(new[] { firstViewController }, UIPageViewControllerNavigationDirection.Forward, false, s =>
 					{
+						Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
 					});
 
 				}
 
 				ConfigurePageControl();
-
-				if (Element.PositionSelected != null)
-					Element.PositionSelected(Element, EventArgs.Empty);
 			}
 		}
 
@@ -322,7 +319,7 @@ namespace CarouselView.FormsPlugin.iOS
 				else
 					firstViewController = CreateViewController(0);
 				
-				pageController.SetViewControllers(new[] { firstViewController }, UIPageViewControllerNavigationDirection.Forward, false, s =>
+				pageController.SetViewControllers(new[] { firstViewController }, UIPageViewControllerNavigationDirection.Forward, Element.AnimateTransition, s =>
 				{
 				});
 
@@ -344,14 +341,12 @@ namespace CarouselView.FormsPlugin.iOS
 				Element.Position = position;
 
 				var firstViewController = CreateViewController(position);
-				pageController.SetViewControllers(new[] { firstViewController }, direction, true, s =>
+				pageController.SetViewControllers(new[] { firstViewController }, direction, Element.AnimateTransition, s =>
 				{
+					Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
 				});
 
 				ConfigurePageControl();
-
-				if (Element.PositionSelected != null)
-					Element.PositionSelected(Element, EventArgs.Empty);
 			}
 		}
 


### PR DESCRIPTION
Here are the changes we discussed in issue #47 

I didn't update the UWP project because I don't know anything about that, but I updated iOS and Android and tested them. I also added the dlls to my real application and verified that it fixed my issues there.