### PR TITLE
Added support for different Views for same BindingContext

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -102,6 +102,9 @@ namespace CarouselView.FormsPlugin.Android
 
 			switch (e.PropertyName)
 			{
+				case "Position":
+					SetCurrentItem(Element.Position);
+					break;
 				case "Width":
 					//var rect = this.Element.Bounds;
 					break;

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -293,13 +293,20 @@ namespace CarouselView.FormsPlugin.Android
 				if (Element.ItemsSource != null && Element.ItemsSource?.Count > 0)
 				    bindingContext = Element.ItemsSource.Cast<object> ().ElementAt (position);
 
-				var selector = Element.ItemTemplate as DataTemplateSelector;
-				if (selector != null)
-					formsView = (View)selector.SelectTemplate (bindingContext, Element).CreateContent ();
-				else
-					formsView = (View)Element.ItemTemplate.CreateContent ();
+				var dt = bindingContext as DataTemplate;
 
-				formsView.BindingContext = bindingContext;
+				if(dt != null){
+					formsView = dt.CreateContent();
+				}else{
+
+					var selector = Element.ItemTemplate as DataTemplateSelector;
+					if (selector != null)
+						formsView = (View)selector.SelectTemplate (bindingContext, Element).CreateContent ();
+					else
+						formsView = (View)Element.ItemTemplate.CreateContent ();
+
+					formsView.BindingContext = bindingContext;
+				}
 				formsView.Parent = this.Element;
 
 				// Width in dip and not in pixels. (all Xamarin.Forms controls use dip for their WidthRequest and HeightRequest)

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -353,13 +353,19 @@ namespace CarouselView.FormsPlugin.UWP
             Xamarin.Forms.View formsView = null;
             var bindingContext = item;
 
-            var selector = Element.ItemTemplate as Xamarin.Forms.DataTemplateSelector;
-            if (selector != null)
-                formsView = (Xamarin.Forms.View)selector.SelectTemplate(bindingContext, Element).CreateContent();
-            else
-                formsView = (Xamarin.Forms.View)Element.ItemTemplate.CreateContent();
+            var dt = bindingContext as DataTemplate;
 
-            formsView.BindingContext = bindingContext;
+            if(dt != null){
+                formsView = dt.CreateContent();
+            }else{
+                var selector = Element.ItemTemplate as Xamarin.Forms.DataTemplateSelector;
+                if (selector != null)
+                    formsView = (Xamarin.Forms.View)selector.SelectTemplate(bindingContext, Element).CreateContent();
+                else
+                    formsView = (Xamarin.Forms.View)Element.ItemTemplate.CreateContent();
+
+                formsView.BindingContext = bindingContext;
+            }
 			formsView.Parent = this.Element;
 
             var element = FormsViewToNativeUWP.ConvertFormsToNative(formsView, new Xamarin.Forms.Rectangle(0, 0, ElementWidth, ElementHeight));

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -111,6 +111,9 @@ namespace CarouselView.FormsPlugin.UWP
 
             switch (e.PropertyName)
             {
+                case "Position":
+                    this.SetCurrentItem(Element.Position);
+                    break;
                 case "Width":
                     if (ElementWidth == 0)
                         ElementWidth = rect.Width;

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -246,6 +246,9 @@ namespace CarouselView.FormsPlugin.iOS
 
 			switch (e.PropertyName)
 			{
+				case "Position":
+					this.SetCurrentController(Element.Position);
+					break;
 				case "Width":
 					ElementWidth = rect.Width;
 					break;

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -403,13 +403,18 @@ namespace CarouselView.FormsPlugin.iOS
 			if (Element.ItemsSource != null && Element.ItemsSource?.Count > 0)
 				bindingContext = Element.ItemsSource.Cast<object>().ElementAt(index);
 
-			var selector = Element.ItemTemplate as DataTemplateSelector;
-			if (selector != null)
-				formsView = (Xamarin.Forms.View)selector.SelectTemplate(bindingContext, Element).CreateContent();
-			else
-				formsView = (Xamarin.Forms.View)Element.ItemTemplate.CreateContent();
+			var dt = bindingContext as DataTemplate;
+			if(dt != null){
+				formsView = dt.CreateContent();
+			}else{
+				var selector = Element.ItemTemplate as DataTemplateSelector;
+				if (selector != null)
+					formsView = (Xamarin.Forms.View)selector.SelectTemplate(bindingContext, Element).CreateContent();
+				else
+					formsView = (Xamarin.Forms.View)Element.ItemTemplate.CreateContent();
 
-			formsView.BindingContext = bindingContext;
+				formsView.BindingContext = bindingContext;
+			}
 			formsView.Parent = this.Element;
 
 			// UIScreen.MainScreen.Bounds.Width, UIScreen.MainScreen.Bounds.Height


### PR DESCRIPTION
In case, when we just want to display different View for the same data, we can provide `List<DataTemplate>` as `ItemsSource`, as `DataTemplate` does not have `BindingContext`, it just needs to inherit `BindingContext` of `CarouselView`.

Also added ability to change `Position` from MVVM binding.