### PR TITLE
Fix "The specified child already has a parent" crash

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -300,7 +300,8 @@ namespace CarouselView.FormsPlugin.Android
 					formsView = (View)Element.ItemTemplate.CreateContent ();
 
 				formsView.BindingContext = bindingContext;
-				formsView.Parent = this.Element;
+				if(formsView.Parent == null)
+				    formsView.Parent = this.Element;
 
 				// Width in dip and not in pixels. (all Xamarin.Forms controls use dip for their WidthRequest and HeightRequest)
 				// Resources.DisplayMetrics.WidthPixels / Resources.DisplayMetrics.Density


### PR DESCRIPTION
Android was crashing when the apps state switched from "in background" to front with "The specified child already has a parent. You must call removeView() on the child's parent first" -> just keeping the parent when its already set fixes the issue for me

I actually only changed line 303 by adding "if(formsView.Parent == null)"