### PR TITLE
Fix for issues after recreating the control on iOS

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -73,6 +73,12 @@ namespace CarouselView.FormsPlugin.iOS
 				Element.RemoveAction = new Action<int>(RemoveController);
 				Element.InsertAction = new Action<object, int>(InsertController);
 			}
+
+			var element = e.OldElement ?? e.NewElement;
+			if (element != null && element.Position > -1)
+			{
+				prevPosition = element.Position;
+			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -367,7 +373,7 @@ namespace CarouselView.FormsPlugin.iOS
 				{
 					ConfigurePageControl();
 
-					Element.PositionSelected?.Invoke(Element, EventArgs.Empty);
+					Element?.PositionSelected?.Invoke(Element, EventArgs.Empty);
 				});
 			}
 		}


### PR DESCRIPTION
If we recreate the control without changing the current BindingContext (for example recreating the control on orientation change, with changed width size), the control has't stored the previous state, so the position changing animation could be happen to the wrong direction. 
Also, there was a NullReferenceException, because a delegate called during recreation, when the Element had a null value.