### PR TITLE
support carousel as layout control

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
@@ -38,6 +38,7 @@
     <DocumentationFile>bin\Release\CarouselView.FormsPlugin.Abstractions.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CarouselViewLayout.cs" />
     <Compile Include="CarouselViewControl.cs" />
     <Compile Include="ICarouselView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselView.FormsPlugin.Abstractions.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CarouselViewControl.cs" />
+    <Compile Include="ICarouselView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CarouselViewOrientation.cs" />
     <Compile Include="IndicatorsShape.cs" />

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 
 namespace CarouselView.FormsPlugin.Abstractions
 {
-	/// <summary>
+    /// <summary>
 	/// CarouselView Interface
 	/// </summary>
-	public class CarouselViewControl : View
+	public class CarouselViewControl : View, ICarouselView
 	{
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(CarouselViewOrientation), typeof(CarouselViewControl), CarouselViewOrientation.Horizontal);
 
@@ -109,6 +109,6 @@ namespace CarouselView.FormsPlugin.Abstractions
 			set { SetValue(ShowArrowsProperty, value); }
 		}
 
-		public EventHandler<int> PositionSelected;
+		public EventHandler<int> PositionSelected { get; set; }
 	}
 }

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewLayout.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewLayout.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Xamarin.Forms;
+using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace CarouselView.FormsPlugin.Abstractions
+{
+	/// <summary>
+	/// CarouselView Interface
+	/// </summary>
+	public class CarouselViewLayout : Layout<View>, ICarouselView
+	{
+		public CarouselViewLayout()
+	    {
+	        ItemsSource = this.Children;
+	    }
+
+		public static readonly BindableProperty OrientationProperty = BindableProperty.Create("Orientation", typeof(CarouselViewOrientation), typeof(CarouselViewLayout), CarouselViewOrientation.Horizontal);
+
+		public CarouselViewOrientation Orientation
+		{
+			get { return (CarouselViewOrientation)GetValue(OrientationProperty); }
+			set { SetValue(OrientationProperty, value); }
+		}
+
+		// Android and iOS only
+		public static readonly BindableProperty InterPageSpacingProperty = BindableProperty.Create("InterPageSpacing", typeof(int), typeof(CarouselViewLayout), 0);
+
+		public int InterPageSpacing
+		{
+			get { return (int)GetValue(InterPageSpacingProperty); }
+			set { SetValue(InterPageSpacingProperty, value); }
+		}
+
+		public static readonly BindableProperty IsSwipingEnabledProperty = BindableProperty.Create("IsSwipingEnabled", typeof(bool), typeof(CarouselViewLayout), true);
+
+		public bool IsSwipingEnabled
+		{
+			get { return (bool)GetValue(IsSwipingEnabledProperty); }
+			set { SetValue(IsSwipingEnabledProperty, value); }
+		}
+
+		public static readonly BindableProperty IndicatorsTintColorProperty = BindableProperty.Create("IndicatorsTintColor", typeof(Color), typeof(CarouselViewLayout), Color.Silver);
+
+		public Color IndicatorsTintColor
+		{
+			get { return (Color)GetValue(IndicatorsTintColorProperty); }
+			set { SetValue(IndicatorsTintColorProperty, value); }
+		}
+
+		public static readonly BindableProperty CurrentPageIndicatorTintColorProperty = BindableProperty.Create("CurrentPageIndicatorTintColor", typeof(Color), typeof(CarouselViewLayout), Color.Gray);
+
+		public Color CurrentPageIndicatorTintColor
+		{
+			get { return (Color)GetValue(CurrentPageIndicatorTintColorProperty); }
+			set { SetValue(CurrentPageIndicatorTintColorProperty, value); }
+		}
+
+		public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create("IndicatorsShape", typeof(IndicatorsShape), typeof(CarouselViewLayout), IndicatorsShape.Circle);
+
+		public IndicatorsShape IndicatorsShape
+		{
+			get { return (IndicatorsShape)GetValue(IndicatorsShapeProperty); }
+			set { SetValue(IndicatorsShapeProperty, value); }
+		}
+
+		public static readonly BindableProperty ShowIndicatorsProperty = BindableProperty.Create("ShowIndicators", typeof(bool), typeof(CarouselViewLayout), false);
+
+		public bool ShowIndicators
+		{
+			get { return (bool)GetValue(ShowIndicatorsProperty); }
+			set { SetValue(ShowIndicatorsProperty, value); }
+		}
+
+		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(CarouselViewLayout), null);
+
+		public IEnumerable ItemsSource
+		{
+			get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+			set { SetValue(ItemsSourceProperty, value); }
+		}
+
+		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(CarouselViewLayout), null);
+
+		public DataTemplate ItemTemplate
+		{
+			get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+			set { SetValue(ItemTemplateProperty, value); }
+		}
+
+		public static readonly BindableProperty PositionProperty = BindableProperty.Create("Position", typeof(int), typeof(CarouselViewLayout), 0, BindingMode.TwoWay);
+
+		public int Position
+		{
+			get { return (int)GetValue(PositionProperty); }
+			set { SetValue(PositionProperty, value); }
+		}
+
+		public static readonly BindableProperty AnimateTransitionProperty = BindableProperty.Create("AnimateTransition", typeof(bool), typeof(CarouselViewLayout), true);
+
+		public bool AnimateTransition
+		{
+			get { return (bool)GetValue(AnimateTransitionProperty); }
+			set { SetValue(AnimateTransitionProperty, value); }
+		}
+
+		// UWP only
+		public static readonly BindableProperty ShowArrowsProperty = BindableProperty.Create("ShowArrows", typeof(bool), typeof(CarouselViewLayout), false);
+
+		public bool ShowArrows
+		{
+			get { return (bool)GetValue(ShowArrowsProperty); }
+			set { SetValue(ShowArrowsProperty, value); }
+		}
+
+		public EventHandler<int> PositionSelected { get; set; }
+
+	    protected override void LayoutChildren(double x, double y, double width, double height)
+	    {
+	        //  Required for Layout implementations, but it seems we have nothing to do.
+	    }
+	}
+}

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/ICarouselView.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/ICarouselView.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using Xamarin.Forms;
+
+namespace CarouselView.FormsPlugin.Abstractions
+{
+	public interface ICarouselView
+	{
+		CarouselViewOrientation Orientation { get; set; }
+		int InterPageSpacing { get; set; }
+		bool IsSwipingEnabled { get; set; }
+		Color IndicatorsTintColor { get; set; }
+		Color CurrentPageIndicatorTintColor { get; set; }
+		IndicatorsShape IndicatorsShape { get; set; }
+		bool ShowIndicators { get; set; }
+		IEnumerable ItemsSource { get; set; }
+		DataTemplate ItemTemplate { get; set; }
+		int Position { get; set; }
+		bool AnimateTransition { get; set; }
+		bool ShowArrows { get; set; }
+		EventHandler<int> PositionSelected { get; set; }
+	}
+}

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
  */
 
 [assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
+[assembly: ExportRenderer(typeof(CarouselViewLayout), typeof(CarouselViewRenderer<CarouselViewLayout>))]
 namespace CarouselView.FormsPlugin.Android
 {
 	/// <summary>
@@ -465,8 +466,15 @@ namespace CarouselView.FormsPlugin.Android
 				var nativeConverted = formsView.ToAndroid(new Rectangle (0, 0, Element.Width, Element.Height));
 				nativeConverted.Tag = new Tag() { BindingContext = bindingContext }; //position;
 
-                //nativeConverted.SaveEnabled = true;
-                //nativeConverted.RestoreHierarchyState(mViewStates);
+				//nativeConverted.SaveEnabled = true;
+				//nativeConverted.RestoreHierarchyState(mViewStates);
+
+				if (nativeConverted.Parent != null)
+				{
+					var viewPagerParent = nativeConverted.Parent as AViews.IViewManager;
+
+					viewPagerParent.RemoveView(nativeConverted);
+				}
 
 				var pager = (ViewPager)container;
 				pager.AddView (nativeConverted);

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -437,11 +437,16 @@ namespace CarouselView.FormsPlugin.Android
 				    bindingContext = Source.Cast<object> ().ElementAt (position);
 				
 				var dt = bindingContext as DataTemplate;
+				var view = bindingContext as View;
 
                 // Support for List<DataTemplate> as ItemsSource
 				if (dt != null)
 				{
 					formsView = (View)dt.CreateContent();
+				}
+				else if (view != null)
+				{
+					formsView = view;
 				}
 				else {
 

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -26,13 +26,13 @@ using System.Collections.Generic;
  * 
  */
 
-[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer))]
+[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
 namespace CarouselView.FormsPlugin.Android
 {
 	/// <summary>
 	/// CarouselView Renderer
 	/// </summary>
-	public class CarouselViewRenderer : ViewRenderer<CarouselViewControl, AViews.View>
+	public class CarouselViewRenderer<T> : ViewRenderer<T, AViews.View> where T : View, ICarouselView
 	{
 		AViews.View nativeView;
 		ViewPager viewPager;
@@ -42,7 +42,7 @@ namespace CarouselView.FormsPlugin.Android
 		//double ElementWidth;
         //double ElementHeight;
 
-		protected override void OnElementChanged(ElementChangedEventArgs<CarouselViewControl> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<T> e)
 		{
 			base.OnElementChanged(e);
 
@@ -101,7 +101,7 @@ namespace CarouselView.FormsPlugin.Android
 			// NewStartingIndex contains the index where the item was moved to.
 			if (e.Action == NotifyCollectionChangedAction.Move)
 			{
-                var Source = ((PageAdapter)viewPager?.Adapter).Source;
+				var Source = ((PageAdapter<T>)viewPager?.Adapter).Source;
 
 				if (Element != null && viewPager != null && Source != null)
 				{
@@ -116,7 +116,7 @@ namespace CarouselView.FormsPlugin.Android
 			// then they contain the index where the item was replaced.
 			if (e.Action == NotifyCollectionChangedAction.Replace)
 			{
-                var Source = ((PageAdapter)viewPager?.Adapter).Source;
+				var Source = ((PageAdapter<T>)viewPager?.Adapter).Source;
 
 				if (Element != null && viewPager != null && Source != null)
 				{
@@ -131,7 +131,7 @@ namespace CarouselView.FormsPlugin.Android
 				if (Element != null && viewPager != null)
 				{
                     SetPosition();
-					viewPager.Adapter = new PageAdapter(Element);
+					viewPager.Adapter = new PageAdapter<T>(Element);
 					viewPager.SetCurrentItem(Element.Position, false);
 					indicators?.SetViewPager(viewPager);
 					Element.PositionSelected?.Invoke(Element, Element.Position);
@@ -193,7 +193,7 @@ namespace CarouselView.FormsPlugin.Android
 					if (Element != null && viewPager != null)
 					{
 						SetPosition();
-						viewPager.Adapter = new PageAdapter(Element);
+						viewPager.Adapter = new PageAdapter<T>(Element);
 						viewPager.SetCurrentItem(Element.Position, false);
 						indicators?.SetViewPager(viewPager);
 						Element.PositionSelected?.Invoke(Element, Element.Position);
@@ -204,7 +204,7 @@ namespace CarouselView.FormsPlugin.Android
 				case "ItemTemplate":
 					if (Element != null && viewPager != null)
 					{
-						viewPager.Adapter = new PageAdapter(Element);
+						viewPager.Adapter = new PageAdapter<T>(Element);
 						viewPager.SetCurrentItem(Element.Position, false);
 						indicators?.SetViewPager(viewPager);
 						Element.PositionSelected?.Invoke(Element, Element.Position);
@@ -280,7 +280,7 @@ namespace CarouselView.FormsPlugin.Android
 
 			viewPager = nativeView.FindViewById<ViewPager>(Resource.Id.pager);
 
-			viewPager.Adapter = new PageAdapter(Element);
+			viewPager.Adapter = new PageAdapter<T>(Element);
 			viewPager.SetCurrentItem(Element.Position, false);
 
 			// InterPageSpacing BP
@@ -332,7 +332,7 @@ namespace CarouselView.FormsPlugin.Android
 
 		void InsertPage(object item, int position)
 		{
-			var Source = ((PageAdapter)viewPager?.Adapter).Source;
+			var Source = ((PageAdapter<T>)viewPager?.Adapter).Source;
 
 			if (Element != null && viewPager != null && Source != null)
 			{
@@ -350,7 +350,7 @@ namespace CarouselView.FormsPlugin.Android
 		// Android ViewPager is the most complicated piece of code ever :)
 		async Task RemovePage(int position)
 		{
-			var Source = ((PageAdapter)viewPager?.Adapter).Source;
+			var Source = ((PageAdapter<T>)viewPager?.Adapter).Source;
 
 			if (Element != null && viewPager != null && Source != null && Source?.Count > 0) {
 				
@@ -399,9 +399,9 @@ namespace CarouselView.FormsPlugin.Android
 		}
 
 #region adapter
-		class PageAdapter : PagerAdapter
+		class PageAdapter<T> : PagerAdapter where T : View, ICarouselView
 		{
-			CarouselViewControl Element;
+			T Element;
 
 			// A local copy of ItemsSource so we can use CollectionChanged events
 			public List<object> Source;
@@ -410,7 +410,7 @@ namespace CarouselView.FormsPlugin.Android
 			//SparseArray<Parcelable> mViewStates = new SparseArray<Parcelable>();
 			//ViewPager mViewPager;
 
-			public PageAdapter(CarouselViewControl element)
+			public PageAdapter(T element)
 			{
 				Element = element;
 				Source = Element.ItemsSource != null ? new List<object>(Element.ItemsSource.GetList()) : null;

--- a/CarouselView/CarouselView.FormsPlugin.Android/Implementation/CustomViewPager.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/Implementation/CustomViewPager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Android.Content;
+using Android.Runtime;
 using Android.Support.V4.View;
 using Android.Util;
 using Android.Views;
@@ -16,6 +17,11 @@ namespace CarouselView.FormsPlugin.Android
 
 		public CustomViewPager(Context context, IAttributeSet attrs) : base(context, attrs)
 		{
+		}
+
+		public CustomViewPager(IntPtr intPtr, JniHandleOwnership jni) : base(intPtr, jni)
+		{
+		    //  I am a bit worried this is a clone constructor and we are not cloning isSwipingEnabled
 		}
 
 		public override bool OnTouchEvent(MotionEvent ev)

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -17,6 +17,7 @@ using Rectangle = Windows.UI.Xaml.Shapes.Rectangle;
 using Thickness = Windows.UI.Xaml.Thickness;
 
 [assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
+[assembly: ExportRenderer(typeof(CarouselViewLayout), typeof(CarouselViewRenderer<CarouselViewLayout>))]
 namespace CarouselView.FormsPlugin.UWP
 {
     /// <summary>

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -11,19 +11,23 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Shapes;
 using System.Collections.Specialized;
+using Xamarin.Forms;
+using Button = Windows.UI.Xaml.Controls.Button;
+using Rectangle = Windows.UI.Xaml.Shapes.Rectangle;
+using Thickness = Windows.UI.Xaml.Thickness;
 
-[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer))]
+[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
 namespace CarouselView.FormsPlugin.UWP
 {
     /// <summary>
-    /// CarouselView Renderer
+    /// CarouselView Rendererab
     /// </summary>
-    public class CarouselViewRenderer : ViewRenderer<CarouselViewControl, UserControl>
+    public class CarouselViewRenderer<T> : ViewRenderer<T, UserControl> where T : View, ICarouselView
     {
         UserControl nativeView;
         FlipView flipView;
         StackPanel indicators;
-
+            
         ColorConverter converter;
         SolidColorBrush selectedColor;
         SolidColorBrush fillColor;
@@ -42,7 +46,7 @@ namespace CarouselView.FormsPlugin.UWP
 
         bool _disposed;
 
-        protected override void OnElementChanged(ElementChangedEventArgs<CarouselViewControl> e)
+        protected override void OnElementChanged(ElementChangedEventArgs<T> e)
         {
             base.OnElementChanged(e);
 

--- a/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.UWP/CarouselViewImplementation.cs
@@ -473,11 +473,16 @@ namespace CarouselView.FormsPlugin.UWP
             var bindingContext = item;
 
 			var dt = bindingContext as Xamarin.Forms.DataTemplate;
+			var view = bindingContext as Xamarin.Forms.View;
 
-            // Support for List<DataTemplate> as ItemsSource
-            if (dt != null)
+			// Support for List<DataTemplate> as ItemsSource
+			if (dt != null)
 			{
 				formsView = (Xamarin.Forms.View)dt.CreateContent();
+			}
+			else if (view != null)
+			{
+				formsView = view;
 			}
 			else {
 

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -33,6 +33,7 @@ using Xamarin.Forms.Platform.iOS;
  */
 
 [assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
+[assembly: ExportRenderer(typeof(CarouselViewLayout), typeof(CarouselViewRenderer<CarouselViewLayout>))]
 namespace CarouselView.FormsPlugin.iOS
 {
 	/// <summary>

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -32,13 +32,13 @@ using Xamarin.Forms.Platform.iOS;
  * wrapped in InvokeOnMainThread.
  */
 
-[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer))]
+[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer<CarouselViewControl>))]
 namespace CarouselView.FormsPlugin.iOS
 {
 	/// <summary>
 	/// CarouselView Renderer
 	/// </summary>
-	public class CarouselViewRenderer : ViewRenderer<CarouselViewControl, UIView>
+	public class CarouselViewRenderer<T> : ViewRenderer<T, UIView> where T : View, ICarouselView
 	{
 		UIPageViewController pageController;
 		UIPageControl pageControl;
@@ -58,7 +58,7 @@ namespace CarouselView.FormsPlugin.iOS
 		double ElementWidth;
 		double ElementHeight;
 
-		protected override void OnElementChanged(ElementChangedEventArgs<CarouselViewControl> e)
+		protected override void OnElementChanged(ElementChangedEventArgs<T> e)
 		{
 			base.OnElementChanged(e);
 

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -636,11 +636,16 @@ namespace CarouselView.FormsPlugin.iOS
 				bindingContext = Source.Cast<object>().ElementAt(index);
 
 			var dt = bindingContext as DataTemplate;
+			var view = bindingContext as View;
 
 			// Support for List<DataTemplate> as ItemsSource
 			if (dt != null)
 			{
 				formsView = (View)dt.CreateContent();
+			}
+			else if (view != null)
+			{
+				formsView = view;
 			}
 			else
 			{

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -33,6 +33,9 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Pages\CarouselLayoutTest.xaml.cs">
+      <DependentUpon>CarouselLayoutTest.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="App.cs" />
     <Compile Include="Views\MyTemplateSelector.cs" />
@@ -151,10 +154,7 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Pages\" />
-    <Folder Include="ViewModels\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
@@ -172,6 +172,12 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="FodyWeavers.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Pages\CarouselLayoutTest.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
   <Import Project="..\packages\Fody.2.1.0\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.2.1.0\build\portable-net+sl+win+wpa+wp\Fody.targets')" />

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -94,6 +94,9 @@
     <Compile Include="Pages\ListViewCarousel.xaml.cs">
       <DependentUpon>ListViewCarousel.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\ViewWithBindingContextData.xaml.cs">
+      <DependentUpon>ViewWithBindingContextData.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
@@ -154,7 +157,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="Views\ViewWithBindingContextData.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>

--- a/Demo/Pages/CarouselLayoutTest.xaml
+++ b/Demo/Pages/CarouselLayoutTest.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:abstractions="clr-namespace:CarouselView.FormsPlugin.Abstractions;assembly=CarouselView.FormsPlugin.Abstractions"
+             x:Class="Demo.Pages.CarouselLayoutTest">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="Testing CarouselViewLayout" />
+
+            <abstractions:CarouselViewLayout 
+                ShowArrows="true" 
+                ShowIndicators="true"   
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="FillAndExpand">
+                
+                <Label Text="First pane"></Label>
+                <Label Text="Second pane"></Label>
+                <Label Text="Third pane"></Label>
+            </abstractions:CarouselViewLayout>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Demo/Pages/CarouselLayoutTest.xaml
+++ b/Demo/Pages/CarouselLayoutTest.xaml
@@ -2,20 +2,24 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:abstractions="clr-namespace:CarouselView.FormsPlugin.Abstractions;assembly=CarouselView.FormsPlugin.Abstractions"
+             xmlns:views="clr-namespace:Demo.Views;assembly=Demo"
              x:Class="Demo.Pages.CarouselLayoutTest">
     <ContentPage.Content>
         <StackLayout>
-            <Label Text="Testing CarouselViewLayout" />
-
+            <views:ViewWithBindingContextData x:Name="ANameWithBoundData"></views:ViewWithBindingContextData>
+            
             <abstractions:CarouselViewLayout 
                 ShowArrows="true" 
                 ShowIndicators="true"   
                 HorizontalOptions="FillAndExpand"
                 VerticalOptions="FillAndExpand">
                 
-                <Label Text="First pane"></Label>
-                <Label Text="Second pane"></Label>
-                <Label Text="Third pane"></Label>
+                <StackLayout>
+                    <Label Text="First pane"></Label>
+                    <Label Text="{Binding BindingContext.First, Source={x:Reference ANameWithBoundData}}"></Label>
+                </StackLayout>
+                <Label Text="{Binding BindingContext.Second, Source={x:Reference ANameWithBoundData}}"></Label>
+                <Label Text="{Binding BindingContext.Third, Source={x:Reference ANameWithBoundData}}"></Label>
             </abstractions:CarouselViewLayout>
         </StackLayout>
     </ContentPage.Content>

--- a/Demo/Pages/CarouselLayoutTest.xaml.cs
+++ b/Demo/Pages/CarouselLayoutTest.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Demo.Pages
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CarouselLayoutTest : ContentPage
+    {
+        public CarouselLayoutTest()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Demo/Pages/MainPage.xaml.cs
+++ b/Demo/Pages/MainPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Collections.ObjectModel;
 using CarouselView.FormsPlugin.Abstractions;
 using System.Linq;
+using Demo.Pages;
 
 namespace Demo
 {
@@ -54,6 +55,16 @@ namespace Demo
 					//Navigation.PushAsync(new NoSwipePage());
 					//Navigation.PushAsync(new SecondPage());
 					Navigation.PushAsync(new MyTabbedPage());
+				})
+			});
+
+			ToolbarItems.Add(new ToolbarItem
+			{
+				Text = "Layout Test",
+				Order = ToolbarItemOrder.Primary,
+				Command = new Command(() =>
+				{
+					Navigation.PushAsync(new CarouselLayoutTest());
 				})
 			});
 		}

--- a/Demo/Pages/MyTabbedPage.xaml
+++ b/Demo/Pages/MyTabbedPage.xaml
@@ -13,7 +13,8 @@
                                       InterPageSpacing="10"
                                       BackgroundColor="Red"
                                       Orientation="Horizontal"
-                                      ShowIndicators="true"/>
+                                      ShowIndicators="true"
+                                      ShowArrows="true"/>
 	</ContentPage>
 
 	<ContentPage Title="Second">

--- a/Demo/Pages/MyTabbedPage.xaml.cs
+++ b/Demo/Pages/MyTabbedPage.xaml.cs
@@ -11,9 +11,9 @@ namespace Demo
 		{
 			InitializeComponent();
 
-			myCarousel.ItemsSource = new List<DataTemplate>()
+			myCarousel.ItemsSource = new List<object>()
 			{
-				new DataTemplate(() => { return new PhotoUrl(); }),
+				new PhotoUrl(),
 				new DataTemplate(() => { return new Bio(); }),
 				new DataTemplate(() => { return new ContactInfo(); })
 			};

--- a/Demo/Views/ViewWithBindingContextData.xaml
+++ b/Demo/Views/ViewWithBindingContextData.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Demo.Views.ViewWithBindingContextData">
+  <ContentView.Content>
+        <StackLayout>
+        </StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/Demo/Views/ViewWithBindingContextData.xaml.cs
+++ b/Demo/Views/ViewWithBindingContextData.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Demo.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ViewWithBindingContextData : ContentView
+    {
+        public ViewWithBindingContextData()
+        {
+            InitializeComponent();
+            this.BindingContext = new
+            {
+                First = "First property of binding context",
+                Second = "Second property of binding context",
+                Third = "Third property of binding context"
+            };
+        }
+    }
+}

--- a/Droid/MainActivity.cs
+++ b/Droid/MainActivity.cs
@@ -25,7 +25,8 @@ namespace Demo.Droid
 
 			global::Xamarin.Forms.Forms.Init (this, savedInstanceState);
 
-			CarouselViewRenderer.Init ();
+			CarouselViewRenderer<CarouselViewControl>.Init ();
+			CarouselViewRenderer<CarouselViewLayout>.Init();
 
 			LoadApplication (new App ());
 		}

--- a/UWP/App.xaml.cs
+++ b/UWP/App.xaml.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using CarouselView.FormsPlugin.Abstractions;
 
 namespace Demo.UWP
 {
@@ -59,7 +60,7 @@ namespace Demo.UWP
                 rootFrame.NavigationFailed += OnNavigationFailed;
 
 				List<Assembly> assembliesToInclude = new List<Assembly>();
-				assembliesToInclude.Add(typeof(CarouselViewRenderer).GetTypeInfo().Assembly);
+				assembliesToInclude.Add(typeof(CarouselViewRenderer<CarouselViewControl>).GetTypeInfo().Assembly);
 				Xamarin.Forms.Forms.Init(e, assembliesToInclude);
 
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)

--- a/iOS/AppDelegate.cs
+++ b/iOS/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using CarouselView.FormsPlugin.Abstractions;
 using Foundation;
 using UIKit;
 using CarouselView.FormsPlugin.iOS;
@@ -15,7 +15,8 @@ namespace Demo.iOS
 		{
 			global::Xamarin.Forms.Forms.Init ();
 
-			CarouselViewRenderer.Init ();
+			//  Is this still needed?  If so do for layout as well.
+			CarouselViewRenderer<CarouselViewControl>.Init ();
 
 			LoadApplication (new App ());
 

--- a/iOS/AppDelegate.cs
+++ b/iOS/AppDelegate.cs
@@ -15,8 +15,8 @@ namespace Demo.iOS
 		{
 			global::Xamarin.Forms.Forms.Init ();
 
-			//  Is this still needed?  If so do for layout as well.
 			CarouselViewRenderer<CarouselViewControl>.Init ();
+			CarouselViewRenderer<CarouselViewLayout>.Init();
 
 			LoadApplication (new App ());
 


### PR DESCRIPTION
I would like to use a carousel like a regular layout control, where the carousel panes are children of the carousel in the XAML.  It sounds like this was supported in the past, but not anymore because some conflict between IList ItemSource doesn't work with observable collections.

I had a hacky little wrapper that worked somewhat, (exposing an IList which would be assigned to ItemsSource) however it did not support data-binding property.

In this PR I tried to support a proper layout control with the carousel code.  The existing renderrers were abstracted a bit to let them run against this new layout control.

It seems to work fine on Android, but I am getting a crash on iOS and UWP.  I added some complicated binding to the demo page to repro binding scenarios I am trying to enable.