### PR TITLE
Fix for entry focus bug

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselView.FormsPlugin.Android.csproj
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselView.FormsPlugin.Android.csproj
@@ -122,6 +122,9 @@
     <Compile Include="Implementation\IViewPager.cs" />
     <Compile Include="Tag.cs" />
     <Compile Include="Implementation\VerticalViewPager.cs" />
+    <Compile Include="KeyboardService\SoftwareKeyboardService.cs" />
+    <Compile Include="KeyboardService\GlobalLayoutListener.cs" />
+    <Compile Include="KeyboardService\SoftwareKeyboardEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -141,6 +144,9 @@
     <AndroidResource Include="Resources\values\vpi__defaults.xml" />
     <AndroidResource Include="Resources\values\vpi__styles.xml" />
     <AndroidResource Include="Resources\layout\vertical_viewpager.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="KeyboardService\" />
   </ItemGroup>
   <Import Project="..\..\packages\Xamarin.Android.Support.Compat.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Compat.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Compat.targets')" />
   <Import Project="..\..\packages\Xamarin.Android.Support.Core.UI.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Core.UI.25.4.0.1\build\MonoAndroid70\Xamarin.Android.Support.Core.UI.targets')" />

--- a/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/GlobalLayoutListener.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/GlobalLayoutListener.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Android.App;
+using Android.Content;
+using Android.Views;
+using Android.Views.InputMethods;
+using Object = Java.Lang.Object;
+
+namespace CarouselView.FormsPlugin.Android.KeyboardService
+{
+	internal class GlobalLayoutListener : Object, ViewTreeObserver.IOnGlobalLayoutListener
+	{
+		private static InputMethodManager _inputManager;
+		private readonly SoftwareKeyboardService _softwareKeyboardService;
+
+		private static void ObtainInputManager ()
+		{
+			_inputManager = (InputMethodManager)Application.Context.GetSystemService (Context.InputMethodService);
+		}
+
+		public GlobalLayoutListener (SoftwareKeyboardService softwareKeyboardService)
+		{
+			_softwareKeyboardService = softwareKeyboardService;
+			ObtainInputManager ();
+		}
+
+		public void OnGlobalLayout ()
+		{
+			if (_inputManager.Handle == IntPtr.Zero)
+			{
+				ObtainInputManager ();
+			}
+
+			_softwareKeyboardService.InvokeVisibilityChanged (new SoftwareKeyboardEventArgs (_inputManager.IsAcceptingText));
+		}
+	}
+}

--- a/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/SoftwareKeyboardEventArgs.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/SoftwareKeyboardEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace CarouselView.FormsPlugin.Android.KeyboardService
+{
+	public class SoftwareKeyboardEventArgs : EventArgs
+	{
+		public SoftwareKeyboardEventArgs (bool isVisible)
+		{
+			IsVisible = isVisible;
+		}
+
+		public bool IsVisible { get; private set; }
+	}
+}

--- a/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/SoftwareKeyboardService.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/KeyboardService/SoftwareKeyboardService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Android.App;
+
+namespace CarouselView.FormsPlugin.Android.KeyboardService
+{
+	public class SoftwareKeyboardService : SoftwareKeyboardServiceBase
+	{
+		private readonly Activity _activity;
+		private GlobalLayoutListener _globalLayoutListener;
+
+		public SoftwareKeyboardService (Activity activity)
+		{
+			_activity = activity;
+			if (_activity == null)
+				throw new Exception ("Activity can't be null!");
+		}
+
+		public override event EventHandler<SoftwareKeyboardEventArgs> VisibilityChanged
+		{
+			add
+			{
+				base.VisibilityChanged += value;
+				CheckListener ();
+			}
+			remove { base.VisibilityChanged -= value; }
+		}
+
+		private void CheckListener ()
+		{
+			if (_globalLayoutListener == null)
+			{
+				_globalLayoutListener = new GlobalLayoutListener (this);
+				_activity.Window.DecorView.ViewTreeObserver.AddOnGlobalLayoutListener (_globalLayoutListener);
+			}
+		}
+	}
+
+	public abstract class SoftwareKeyboardServiceBase
+	{
+		public virtual event EventHandler<SoftwareKeyboardEventArgs> VisibilityChanged;
+
+		public void InvokeVisibilityChanged (SoftwareKeyboardEventArgs args)
+		{
+			VisibilityChanged?.Invoke (this, args);
+		}
+	}
+}


### PR DESCRIPTION
I've added a new service which is subscribed to the OnGlobalLayout event, and check if the keyboard is visible. The CarouselView's renderer also has to subscribe to the actual page's SizeChanged event, because the Element's SizeChanged event is invoked before the OnGlobalLayout event when the keyboard disappears, so the Element would be recreated before we would be informed that only the keyboard has became hidden.