### PR TITLE
fix for a scenario where the carousel does not show up in Android app…

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -238,6 +238,15 @@ namespace CarouselView.FormsPlugin.Android
         {
             base.OnElementPropertyChanged(sender, e);
 
+            switch (e.PropertyName)
+            {
+                case "Width":
+                case "Height":
+                case "Y":
+                    canSetLayout = true;
+                    break;
+            }
+
             if (Element == null || viewPager == null) return;
 
             var rect = this.Element.Bounds;


### PR DESCRIPTION
… (due the fact canSetLayout variable remains set to false and control does not get properly initialised).