### PR TITLE
Fix bug 369,367 and 358 in iOS and Android (When ItemsSource is null and the calculation…

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -521,7 +521,7 @@ namespace CarouselView.FormsPlugin.Android
         {
             if (prevBtn == null || nextBtn == null) return;
             prevBtn.Visibility = Element.Position == 0 || Element.ItemsSource.GetCount() == 0 ? AViews.ViewStates.Gone : AViews.ViewStates.Visible;
-            nextBtn.Visibility = Element.Position == Element.ItemsSource.GetCount() - 1 || Element.ItemsSource.GetCount() == 0 ? AViews.ViewStates.Gone : AViews.ViewStates.Visible;
+            nextBtn.Visibility = Element.ItemsSource == null || Element.Position == Element.ItemsSource.GetCount() - 1 || Element.ItemsSource.GetCount() == 0 ? AViews.ViewStates.Gone : AViews.ViewStates.Visible;
         }
 
         void SetIndicators()

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -511,7 +511,7 @@ namespace CarouselView.FormsPlugin.iOS
                 pageController.View.AddSubview(prevBtn);
 
                 nextBtn = new UIButton();
-                nextBtn.Hidden = Element.Position == Element.ItemsSource.GetCount() - 1 || Element.ItemsSource.GetCount() == 0;
+                nextBtn.Hidden = Element.ItemsSource == null || Element.Position == Element.ItemsSource.GetCount() - 1 || Element.ItemsSource.GetCount() == 0;
                 nextBtn.BackgroundColor = Element.ArrowsBackgroundColor.ToUIColor();
                 nextBtn.Alpha = Element.ArrowsTransparency;
                 nextBtn.TranslatesAutoresizingMaskIntoConstraints = false;


### PR DESCRIPTION
… for how the arrows should be shown is done an Exception occurs) in iOS.