### PR TITLE
add ScrolledOffset event

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
@@ -160,6 +160,14 @@ namespace CarouselView.FormsPlugin.Abstractions
         {
             Scrolled?.Invoke(this, new ScrolledEventArgs { NewValue = percent, Direction = direction });
         }
+
+        public event EventHandler<ScrolledOffsetEventArgs> ScrolledOffset;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SendScrolledOffset(double offset)
+        {
+            ScrolledOffset?.Invoke(this, new ScrolledOffsetEventArgs { Offset = offset });
+        }
     }
 
 	public class PositionSelectedEventArgs : EventArgs
@@ -171,5 +179,10 @@ namespace CarouselView.FormsPlugin.Abstractions
     {
         public double NewValue { get; set; }
         public ScrollDirection Direction { get; set; }
+    }
+
+    public class ScrolledOffsetEventArgs : EventArgs
+    {
+        public double Offset { get; set; }
     }
 }

--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -355,6 +355,8 @@ namespace CarouselView.FormsPlugin.Android
                 setCurrentPageCalled = false;
                 pageScrolledCount = 0;
             }
+
+            Element.SendScrolledOffset(e.Position + e.PositionOffset);
         }
 
         // To assign position when page selected

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -291,6 +291,7 @@ namespace CarouselView.FormsPlugin.iOS
 
         double percentCompleted;
         nfloat prevPoint;
+        int settledPosition;
 
         void Scroller_Scrolled(object sender, EventArgs e)
         {
@@ -302,17 +303,20 @@ namespace CarouselView.FormsPlugin.iOS
 
             if (Element.Orientation == CarouselViewOrientation.Horizontal)
             {
-                currentPercentCompleted = Math.Floor((Math.Abs(point.X - pageController.View.Frame.Size.Width) / pageController.View.Frame.Size.Width) * 100);
+                var percentage = (point.X - pageController.View.Frame.Size.Width) / pageController.View.Frame.Size.Width;
+                currentPercentCompleted = Math.Floor((Math.Abs(percentage) * 100));
                 direction = prevPoint > point.X ? ScrollDirection.Left : ScrollDirection.Right;
                 prevPoint = point.X;
+                Element.SendScrolledOffset(settledPosition + percentage);
             }
             else
             {
-                currentPercentCompleted = Math.Floor((Math.Abs(point.Y - pageController.View.Frame.Size.Height) / pageController.View.Frame.Size.Height) * 100);
+                var percentage = (point.Y - pageController.View.Frame.Size.Height) / pageController.View.Frame.Size.Height;
+                currentPercentCompleted = Math.Floor((Math.Abs(percentage) * 100));
                 direction = prevPoint > point.Y ? ScrollDirection.Up : ScrollDirection.Down;
                 prevPoint = point.Y;
+                Element.SendScrolledOffset(settledPosition + percentage);
             }
-
 
             if (currentPercentCompleted <= 100 && currentPercentCompleted > percentCompleted)
             {
@@ -333,6 +337,7 @@ namespace CarouselView.FormsPlugin.iOS
 				var position = Source.IndexOf(controller.Tag);
                 isChangingPosition = true;
 				Element.Position = position;
+                settledPosition = position;
 				prevPosition = position;
                 isChangingPosition = false;
                 SetArrowsVisibility();
@@ -788,6 +793,7 @@ namespace CarouselView.FormsPlugin.iOS
 					SetIndicatorsCurrentPage();
 
 					// Invoke PositionSelected as DidFinishAnimating is only called when touch to swipe
+                    settledPosition = Element.Position;
 					Element.SendPositionSelected();
                     Element.PositionSelectedCommand?.Execute(null);
 				});


### PR DESCRIPTION
- the ScrolledOffset value is an addition of the scrolled percentage and the current page postition
-> so scrolling from page 0 to 1 would result in values like 0…0.5…1, scrolling from page 1 to 2 in values like 1…1.5…2, scrolling from page 2 to 3 in values like 2…2.5…3 etc.
- could be benifitial for animating views that stay on the screen next to the carousel view, e.g. a tab indicator