### PR TITLE
Added safety to help resolve issue #404

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -294,6 +294,9 @@ namespace CarouselView.FormsPlugin.iOS
 
         void Scroller_Scrolled(object sender, EventArgs e)
         {
+            if (Element == null)
+                return;
+            
             var scrollView = (UIScrollView)sender;
             var point = scrollView.ContentOffset;
 


### PR DESCRIPTION
In some situations when Scroller_Scrolled is called the Element property can be null which causes a NullReferenceException. See issue #404 