### PR TITLE
Fix for #357 [iOS] System.NullReferenceException: Object reference not set to an instance of an object

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -294,6 +294,9 @@ namespace CarouselView.FormsPlugin.iOS
 
         void Scroller_Scrolled(object sender, EventArgs e)
         {
+            if (Element == null)
+                return;
+
             var scrollView = (UIScrollView)sender;
             var point = scrollView.ContentOffset;
 


### PR DESCRIPTION
I discovered this issue when I rotated one of our iOS devices during the splash/launch screen of our app. In a nutshell: when a user would rotate their device on iOS during the initialization of a CarouselViewRenderer, a "System.NullReferenceException" exception would be thrown because (in this case) the CarouselViewControl (aka `Element`) was equal to `null`.

I've tested this solution on the devices I have at my disposal (all running iOS 11.X) and it appears to be a solid fix. There does not appear to be any negative impact.