### PR TITLE
A usage of the right context.

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -168,7 +168,7 @@ namespace CarouselView.FormsPlugin.Android
                 if (Element == null || viewPager == null) return;
 
                 SetPosition();
-                viewPager.Adapter = new PageAdapter(Element);
+                viewPager.Adapter = new PageAdapter(Element, _context);
                 viewPager.SetCurrentItem(Element.Position, false);
                 SetArrowsVisibility();
                 indicators?.SetViewPager(viewPager);
@@ -270,7 +270,7 @@ namespace CarouselView.FormsPlugin.Android
                     break;
                 case "ItemsSource":
                     SetPosition();
-                    viewPager.Adapter = new PageAdapter(Element);
+                    viewPager.Adapter = new PageAdapter(Element, _context);
                     viewPager.SetCurrentItem(Element.Position, false);
                     SetArrowsVisibility();
                     indicators?.SetViewPager(viewPager);
@@ -280,7 +280,7 @@ namespace CarouselView.FormsPlugin.Android
                         ((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged += ItemsSource_CollectionChanged;
                     break;
                 case "ItemTemplate":
-                    viewPager.Adapter = new PageAdapter(Element);
+                    viewPager.Adapter = new PageAdapter(Element, _context);
                     viewPager.SetCurrentItem(Element.Position, false);
                     indicators?.SetViewPager(viewPager);
                     Element.SendPositionSelected();
@@ -405,7 +405,7 @@ namespace CarouselView.FormsPlugin.Android
                 orientationChanged = false;
             }
 
-            viewPager.Adapter = new PageAdapter(Element);
+            viewPager.Adapter = new PageAdapter(Element, _context);
             viewPager.SetCurrentItem(Element.Position, false);
 
             // InterPageSpacing BP
@@ -642,6 +642,7 @@ namespace CarouselView.FormsPlugin.Android
         class PageAdapter : PagerAdapter
         {
             CarouselViewControl Element;
+            private readonly Context _context;
 
             // A local copy of ItemsSource so we can use CollectionChanged events
             public List<object> Source;
@@ -650,9 +651,10 @@ namespace CarouselView.FormsPlugin.Android
             //SparseArray<Parcelable> mViewStates = new SparseArray<Parcelable>();
             //ViewPager mViewPager;
 
-            public PageAdapter(CarouselViewControl element)
+            public PageAdapter(CarouselViewControl element, Context context)
             {
                 Element = element;
+                _context = context;
                 Source = Element.ItemsSource != null ? new List<object>(Element.ItemsSource.GetList()) : null;
             }
 
@@ -707,7 +709,7 @@ namespace CarouselView.FormsPlugin.Android
                 // HeightRequest fix
                 formsView.Parent = this.Element;
 
-                var nativeConverted = formsView.ToAndroid(new Rectangle(0, 0, Element.Width, Element.Height));
+                var nativeConverted = formsView.ToAndroid(new Rectangle(0, 0, Element.Width, Element.Height), _context);
                 nativeConverted.Tag = new Tag() { BindingContext = bindingContext }; //position;
 
                 //nativeConverted.SaveEnabled = true;

--- a/CarouselView/CarouselView.FormsPlugin.Android/ViewExtensions.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/ViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.Content;
 using Android.Views;
 using AViews = Android.Views;
 using Xamarin.Forms;
@@ -8,13 +9,13 @@ namespace CarouselView.FormsPlugin.Android
 {
     public static class ViewExtensions
     {
-        public static AViews.View ToAndroid(this Xamarin.Forms.View view, Rectangle size)
+        public static AViews.View ToAndroid(this Xamarin.Forms.View view, Rectangle size, Context context)
         {
 			//var vRenderer = RendererFactory.GetRenderer (view);
 
             // NullReferenceException during swiping #314 (ScrollView)
             if (Platform.GetRenderer(view) == null || Platform.GetRenderer(view)?.Tracker == null)
-				Platform.SetRenderer(view, Platform.CreateRenderer(view));
+				Platform.SetRenderer(view, Platform.CreateRendererWithContext(view, context));
             
 			var vRenderer = Platform.GetRenderer(view);
             


### PR DESCRIPTION
Hi Alex. I noticed that in your plugin you are using a deprecated method `CreateRenderer`. It causes problems with the right context when you are using more than one activity. Can you merge my changes and prepere new nuget?

Best regards,
Błażej Kosmowski