### PR TITLE
Fix #483 

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -137,9 +137,9 @@ namespace CarouselView.FormsPlugin.Android
                 var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
 
                 if (Element == null || viewPager == null || viewPager?.Adapter == null || Source == null) return;
-                    
+
                 Source.RemoveAt(e.OldStartingIndex);
-                Source.Insert(e.NewStartingIndex, e.OldItems[e.OldStartingIndex]);
+                Source.InsertRange(e.NewStartingIndex, e.OldItems.Cast<object>());
                 viewPager.Adapter?.NotifyDataSetChanged();
 
                 SetArrowsVisibility();

--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -126,7 +126,7 @@ namespace CarouselView.FormsPlugin.iOS
                 if (Element == null && pageController == null && Source == null) return;
                     
 				Source.RemoveAt(e.OldStartingIndex);
-				Source.Insert(e.NewStartingIndex, e.OldItems[e.OldStartingIndex]);
+                Source.InsertRange(e.NewStartingIndex, e.OldItems.Cast<object>());
 
 				var firstViewController = CreateViewController(e.NewStartingIndex);
 


### PR DESCRIPTION
Android: moving an item that is not the first one throws out of bounds exception