### PR TITLE
Fix for PositionSelectedCommand not working with custom Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ UWP/bin
 UWP/obj
 packages
 *.userprefs
+/.vs/CarouselView
+/CarouselView/CarouselView.FormsPlugin.Abstractions.Portable/bin/Debug
+/CarouselView/CarouselView.FormsPlugin.Abstractions.Portable/obj/Debug
+/Droid/Demo.Droid.csproj.user

--- a/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Abstractions/CarouselViewControl.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Windows.Input;
 
 namespace CarouselView.FormsPlugin.Abstractions
 {
@@ -134,14 +135,14 @@ namespace CarouselView.FormsPlugin.Abstractions
             set { SetValue(ArrowsTransparencyProperty, value); }
         }
 
-        public static readonly BindableProperty PositionSelectedCommandProperty = BindableProperty.Create("PositionSelectedCommand", typeof(Command), typeof(CarouselViewControl), null, BindingMode.Default, (bindable, value) =>
+        public static readonly BindableProperty PositionSelectedCommandProperty = BindableProperty.Create("PositionSelectedCommand", typeof(ICommand), typeof(CarouselViewControl), null, BindingMode.Default, (bindable, value) =>
         {
             return true;
         });
 
-        public Command PositionSelectedCommand
+        public ICommand PositionSelectedCommand
         {
-            get { return (Command)GetValue(PositionSelectedCommandProperty); }
+            get { return (ICommand)GetValue(PositionSelectedCommandProperty); }
             set { SetValue(PositionSelectedCommandProperty, value); }
         }
 

--- a/Demo/MainViewModel.cs
+++ b/Demo/MainViewModel.cs
@@ -38,7 +38,7 @@ namespace Demo
             }
         }
 
-        public Command MyCommand { protected set; get; }
+        public ICommand MyCommand { protected set; get; }
 
         protected virtual void OnPropertyChanged(string propertyName)
         {

--- a/iOS/Demo.iOS.csproj
+++ b/iOS/Demo.iOS.csproj
@@ -29,7 +29,8 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer: Alexander Reyes (T3VKUDC3C3)</CodesignKey>
     <MtouchProfiling>true</MtouchProfiling>
-    <CodesignProvision></CodesignProvision>
+    <CodesignProvision>
+    </CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -106,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Resources\Images.xcassets\AppIcons.appiconset\Contents.json">
-      <InProject>false</InProject>
+      <Visible>false</Visible>
     </ImageAsset>
   </ItemGroup>
   <ItemGroup>
@@ -126,6 +127,8 @@
     <ProjectReference Include="..\CarouselView\CarouselView.FormsPlugin.iOS\CarouselView.FormsPlugin.iOS.csproj">
       <Project>{D525F236-6A2D-4010-B1CC-4A4B8581C90B}</Project>
       <Name>CarouselView.FormsPlugin.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
     <ProjectReference Include="..\CarouselView\CarouselView.FormsPlugin.Abstractions\CarouselView.FormsPlugin.Abstractions.csproj">
       <Project>{36E4C107-3B10-4DC6-8E6A-BA251DC3BAF3}</Project>


### PR DESCRIPTION
Files Changed:
1. MainViewModel in Demo.csproj
2. CarouselViewControl in CarouselView.FormsPlugin.Abstractions

Fixed the bindable property to correctly accept and return custom ICommand implementations, to work with Prism for example.
