### PR TITLE
Fixed NullReferenceException with Auto Scroll Behaviour

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -294,6 +294,9 @@ namespace CarouselView.FormsPlugin.iOS
 
         void Scroller_Scrolled(object sender, EventArgs e)
         {
+	    if (Element == null)
+	        return;
+	
             var scrollView = (UIScrollView)sender;
             var point = scrollView.ContentOffset;
 


### PR DESCRIPTION
Fixes an issue when navigating away to a different page while an [Auto Scroll Behaviour](https://gist.github.com/salvador-guerrero/a8332a917af40f944ed8c3feb70eaca3) is active causes a crash.

```
CarouselViewRenderer.Scroller_Scrolled (System.Object sender, System.EventArgs e)
UIScrollView+_UIScrollViewDelegate.Scrolled (UIKit.UIScrollView scrollView) /Library/Frameworks/Xamarin.iOS.framework/Versions/12.10.0.157/src/Xamarin.iOS/UIKit/UIScrollView.g.cs:1474
(wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain(int,string[],intptr,intptr)
UIApplication.Main (System.String[] args, System.IntPtr principal, System.IntPtr delegate) /Library/Frameworks/Xamarin.iOS.framework/Versions/12.10.0.157/src/Xamarin.iOS/UIKit/UIApplication.cs:86
UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName) /Library/Frameworks/Xamarin.iOS.framework/Versions/12.10.0.157/src/Xamarin.iOS/UIKit/UIApplication.cs:65
Application.Main (System.String[] args) /Users/vsts/agent/2.155.1/work/1/s/Digistudies/Digistudies.App.iOS/Main.cs:17
```