### PR TITLE
fix a NullPointerException bug caused when keyboardService is null

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.Android/CarouselViewImplementation.cs
@@ -16,6 +16,7 @@ using Android.Content;
 using Android.App;
 using Com.ViewPagerIndicator;
 
+
 /*
  * Save state in Android:
  * 
@@ -30,7 +31,7 @@ using Com.ViewPagerIndicator;
  * 
  */
 
-[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselViewRenderer))]
+[assembly: ExportRenderer(typeof(CarouselViewControl), typeof(CarouselView.FormsPlugin.Android.CarouselViewRenderer))]
 namespace CarouselView.FormsPlugin.Android
 {
     /// <summary>
@@ -67,9 +68,22 @@ namespace CarouselView.FormsPlugin.Android
             _context = context;
 
             // KeyboardService code
-            var activity = _context as Activity;
+            var activity = findActivity(_context);
             if (activity != null)
                 keyboardService = new SoftKeyboardService(activity);
+        }
+
+        private Activity findActivity(Context context)
+        {
+            var activity = context as Activity;
+            if (activity != null)
+            {
+                return activity;
+            }
+            var contextThemeWrapper = _context as AViews.ContextThemeWrapper;
+            if (contextThemeWrapper != null)
+                return findActivity(contextThemeWrapper.BaseContext);
+            return null;
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<CarouselViewControl> e)
@@ -88,14 +102,15 @@ namespace CarouselView.FormsPlugin.Android
                 // Unsubscribe from event handlers and cleanup any resources
 
                 if (Element == null) return;
-                    
+
                 Element.SizeChanged -= Element_SizeChanged;
                 if (Element.ItemsSource != null && Element.ItemsSource is INotifyCollectionChanged)
                     ((INotifyCollectionChanged)Element.ItemsSource).CollectionChanged -= ItemsSource_CollectionChanged;
 
                 // KeyboardService code
                 Xamarin.Forms.Application.Current.MainPage.SizeChanged -= MainPage_SizeChanged;
-                keyboardService.VisibilityChanged -= KeyboardService_VisibilityChanged;
+                if (keyboardService != null)
+                    keyboardService.VisibilityChanged -= KeyboardService_VisibilityChanged;
             }
 
             if (e.NewElement != null)
@@ -108,7 +123,8 @@ namespace CarouselView.FormsPlugin.Android
 
                 // KeyboardService code
                 Xamarin.Forms.Application.Current.MainPage.SizeChanged += MainPage_SizeChanged;
-                keyboardService.VisibilityChanged += KeyboardService_VisibilityChanged;
+                if (keyboardService != null)
+                    keyboardService.VisibilityChanged += KeyboardService_VisibilityChanged;
             }
         }
 
@@ -137,7 +153,7 @@ namespace CarouselView.FormsPlugin.Android
                 var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
 
                 if (Element == null || viewPager == null || viewPager?.Adapter == null || Source == null) return;
-                    
+
                 Source.RemoveAt(e.OldStartingIndex);
                 Source.Insert(e.NewStartingIndex, e.OldItems[e.OldStartingIndex]);
                 viewPager.Adapter?.NotifyDataSetChanged();
@@ -153,8 +169,8 @@ namespace CarouselView.FormsPlugin.Android
             // then they contain the index where the item was replaced.
             if (e.Action == NotifyCollectionChangedAction.Replace)
             {
-				// Fix for #168 Android NullReferenceException
-				var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
+                // Fix for #168 Android NullReferenceException
+                var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
 
                 if (Element == null || viewPager == null || viewPager?.Adapter == null || Source == null) return;
 
@@ -425,7 +441,7 @@ namespace CarouselView.FormsPlugin.Android
 
             // TapGestureRecognizer doesn't work when added to CarouselViewControl (Android) #66, #191, #200
             ((IViewPager)viewPager)?.SetElement(Element);
-            
+
             SetNativeControl(nativeView);
 
             // ARROWS
@@ -572,8 +588,8 @@ namespace CarouselView.FormsPlugin.Android
         // Android ViewPager is the most complicated piece of code ever :)
         async Task RemovePage(int position)
         {
-			// Fix for #168 Android NullReferenceException
-			var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
+            // Fix for #168 Android NullReferenceException
+            var Source = ((PageAdapter)viewPager?.Adapter)?.Source;
 
             if (Element == null || viewPager == null || viewPager?.Adapter == null || Source == null) return;
 
@@ -621,7 +637,7 @@ namespace CarouselView.FormsPlugin.Android
             setCurrentPageCalled = true;
 
             if (Element == null || viewPager == null || Element.ItemsSource == null) return;
-            
+
             if (Element.ItemsSource?.GetCount() > 0)
             {
                 viewPager.SetCurrentItem(position, Element.AnimateTransition);
@@ -784,23 +800,23 @@ namespace CarouselView.FormsPlugin.Android
                     nextBtn = null;
                 }
 
-				if (indicators != null)
-				{
-					indicators.Dispose();
-					indicators = null;
-				}
+                if (indicators != null)
+                {
+                    indicators.Dispose();
+                    indicators = null;
+                }
 
-				if (viewPager != null)
-				{
-					viewPager.PageSelected -= ViewPager_PageSelected;
-					viewPager.PageScrollStateChanged -= ViewPager_PageScrollStateChanged;
+                if (viewPager != null)
+                {
+                    viewPager.PageSelected -= ViewPager_PageSelected;
+                    viewPager.PageScrollStateChanged -= ViewPager_PageScrollStateChanged;
 
-					if (viewPager.Adapter != null)
-						viewPager.Adapter.Dispose();
+                    if (viewPager.Adapter != null)
+                        viewPager.Adapter.Dispose();
 
-					viewPager.Dispose();
-					viewPager = null;
-				}
+                    viewPager.Dispose();
+                    viewPager = null;
+                }
 
                 if (Element != null)
                 {


### PR DESCRIPTION
I found  the bug was in use CarouselView in a CollectionView.
I read the source code and found that the context in the CollectionViewRenderer constructor is ContextThemeWrapper. This caused the context in the CarouselViewRenderer constructor to not be converted to an Activity, which caused the keyboardService to not be instantiated correctly, so I fixed this problem.
Thanks