### PR TITLE
Fix for updating position of a CarouselView on iOS

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -869,7 +869,7 @@ namespace CarouselView.FormsPlugin.iOS
             }
         }
 
-        bool prevBtnClicked;
+        bool? prevBtnClicked;
 
         void PrevBtn_TouchUpInside(object sender, EventArgs e)
         {
@@ -1180,9 +1180,10 @@ namespace CarouselView.FormsPlugin.iOS
             if (Element.ItemsSource?.GetCount() > 0)
             {
                 // Transition direction based on prevPosition or if prevBtn has been clicked
-                var navdirection = position >= prevPosition || !prevBtnClicked ? UIPageViewControllerNavigationDirection.Forward : UIPageViewControllerNavigationDirection.Reverse;
+                var navdirection = position >= prevPosition || (prevBtnClicked.HasValue ? !prevBtnClicked.Value : false) ? UIPageViewControllerNavigationDirection.Forward : UIPageViewControllerNavigationDirection.Reverse;
 
-                prevBtnClicked = false;
+                if(prevBtnClicked.HasValue)
+                    prevBtnClicked = false;
 
                 var firstViewController = CreateViewController(position);
 


### PR DESCRIPTION
Fixed an issue on iOS where updating position of a CarouselView always transitions from the rightsize (forward). The CarouselView always bases the direction transition on the value of ```prevBtnClicked```. In my case I want to change the position outside of the arrows. 

This code works both when you have the ```ShowArrows``` set to true and change the position outside of the arrows.