### PR TITLE
[iOS] Fix transitioning direction of a CarouselView when position changed

### DIFF
--- a/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
+++ b/CarouselView/CarouselView.FormsPlugin.iOS/CarouselViewImplementation.cs
@@ -869,7 +869,7 @@ namespace CarouselView.FormsPlugin.iOS
             }
         }
 
-        bool prevBtnClicked;
+        bool? prevBtnClicked;
 
         void PrevBtn_TouchUpInside(object sender, EventArgs e)
         {
@@ -1180,9 +1180,10 @@ namespace CarouselView.FormsPlugin.iOS
             if (Element.ItemsSource?.GetCount() > 0)
             {
                 // Transition direction based on prevPosition or if prevBtn has been clicked
-                var navdirection = position >= prevPosition || !prevBtnClicked ? UIPageViewControllerNavigationDirection.Forward : UIPageViewControllerNavigationDirection.Reverse;
+                var navdirection = position >= prevPosition || (prevBtnClicked.HasValue ? !prevBtnClicked.Value : false)  ? UIPageViewControllerNavigationDirection.Forward : UIPageViewControllerNavigationDirection.Reverse;
 
-                prevBtnClicked = false;
+                if(prevBtnClicked.HasValue)
+                    prevBtnClicked = false;
 
                 var firstViewController = CreateViewController(position);
 


### PR DESCRIPTION
Fixed an issue on iOS where updating the position of a CarouselView programmatically would always animate the transitions from right to left even when going down on the positioncounter.

Currently the CarouselView always bases the direction transition on the value of ```prevBtnClicked``` even if ```ShowArrows``` is set to false in XAML. This PR fixes that.

To reproduce this problem you can create a clean project, which includes the CarouselView and the ShowArrows is set to true, and press the previous arrow.
